### PR TITLE
docs: update demo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CSS/JS theme library that applies iOS26 design system to Ionic applications.
 
 ![iOS 26 themed Ionic screens with Liquid Glass tab bar, lists, and controls](https://raw.githubusercontent.com/rdlabo-dev/ionic-theme-ios26/v2.3.2/screenshots/ios26.png)
 
-DEMO is here: https://ionic-theme-ios26.netlify.app/
+DEMO is here: https://ionic-theme-ios26.rdlabo.dev/
 
 ## Overview
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,4 +33,4 @@ ion-textarea label.textarea-wrapper {
 
 To achieve higher fidelity to iOS26 design, you can implement additional design provided by this library. For more details, please visit:
 
-https://ionic-theme-ios26.netlify.app/main/docs
+https://ionic-theme-ios26.rdlabo.dev/main/docs


### PR DESCRIPTION
## Summary
- replace the retired Netlify demo URL with the canonical Ionic 9 Cloudflare URL
- update the feature documentation link to the new demo host
- retain the Ionic 8 compatibility demo link in the development section

## Verification
- confirmed the Ionic 9 root and `/main/docs` URLs return HTTP 200
- confirmed the Ionic 8 demo URL returns HTTP 200
- confirmed no old Netlify demo URL remains