### PR TITLE
docs: use stable release links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A CSS/JS theme library that applies iOS26 design system to Ionic applications.
 
-![iOS 26 themed Ionic screens with Liquid Glass tab bar, lists, and controls](https://raw.githubusercontent.com/rdlabo-dev/ionic-theme-ios26/v3.0.0-1/screenshots/ios26.png)
+![iOS 26 themed Ionic screens with Liquid Glass tab bar, lists, and controls](https://raw.githubusercontent.com/rdlabo-dev/ionic-theme-ios26/v3.0.0/screenshots/ios26.png)
 
 DEMO is here: https://ionic-theme-ios26.rdlabo.dev/
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ Customize the theme with CSS variables and Sass mixins, or adopt it one componen
 ## CSS variables
 
 To customize the library's default styles to match your design, several CSS variables are provided. See this file for details:
-https://github.com/rdlabo-dev/ionic-theme-ios26/blob/v3.0.0-1/src/styles/default-variables.scss
+https://github.com/rdlabo-dev/ionic-theme-ios26/blob/v3.0.0/src/styles/default-variables.scss
 
 ## Liquid Glass mixin
 

--- a/docs/using-ion-item-group.md
+++ b/docs/using-ion-item-group.md
@@ -24,7 +24,7 @@ No wrapper is required for lists that do not use `inset="true"`.
 
 Ionic normally gives `ion-list` its background, which makes `ion-list-header` appear inside the same surface as the items. The iOS 26 layout treats the header and item surface separately.
 
-![Inset list background comparison showing why ion-item-group is required](https://raw.githubusercontent.com/rdlabo-dev/ionic-theme-ios26/v3.0.0-1/screenshots/why-ion-list-inset.png)
+![Inset list background comparison showing why ion-item-group is required](https://raw.githubusercontent.com/rdlabo-dev/ionic-theme-ios26/v3.0.0/screenshots/why-ion-list-inset.png)
 
 The theme therefore:
 


### PR DESCRIPTION
## Summary

- point README and guide images to the stable `v3.0.0` tag
- point the documented variables source to the stable release

## Validation

- Prettier check
- `git diff --check`

## Related

Required before rdlabo-dev/docs#11 can validate its stable-release source contract.
