### PR TITLE
fix: support helper and error text outside inset lists

### DIFF
--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -1,6 +1,7 @@
 @use '../utils/structured-list';
 
 ion-list.ios:not(.ios26-disabled) {
+  @include structured-list.support-text;
   ion-item {
     --background-hover-opacity: 0;
     --background-focused-opacity: 0;

--- a/src/styles/md-ion-list-inset.scss
+++ b/src/styles/md-ion-list-inset.scss
@@ -1,18 +1,21 @@
 @use 'utils/structured-list';
 
-ion-list.list-inset.md {
-  @include structured-list.layout(8px, 16px);
+ion-list.md {
+  @include structured-list.support-text;
 
-  ion-item-group > ion-item {
-    & > ion-input[labelplacement='floating'] {
-      transition: transform 200ms ease;
+  &.list-inset {
+    @include structured-list.layout(8px, 16px);
+    ion-item-group > ion-item {
+      & > ion-input[labelplacement='floating'] {
+        transition: transform 200ms ease;
 
-      &:not(.label-floating) {
-        transform: translateY(-7px);
-      }
+        &:not(.label-floating) {
+          transform: translateY(-7px);
+        }
 
-      &.label-floating {
-        transform: translateY(-4px);
+        &.label-floating {
+          transform: translateY(-4px);
+        }
       }
     }
   }

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -1,3 +1,22 @@
+@mixin support-text() {
+  ion-item {
+    &:has(ion-input.input-fill-outline),
+    &:has(ion-textarea.textarea-fill-outline),
+    &:has(ion-select:is([helpertext]:not([helpertext='']), [errortext]:not([errortext='']))),
+    &:has(ion-input .input-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))),
+    &:has(ion-textarea .textarea-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))) {
+      --inner-border-width: 0;
+      --inner-padding-bottom: 4px;
+    }
+
+    ion-select .select-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
+    ion-input .input-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
+    ion-textarea .textarea-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))) {
+      display: none;
+    }
+  }
+}
+
 @mixin layout($outer-note-inset, $group-border-radius) {
   background: transparent;
 
@@ -89,20 +108,6 @@
     }
 
     ion-item {
-      &:has(ion-input.input-fill-outline),
-      &:has(ion-textarea.textarea-fill-outline),
-      &:has(ion-select:is([helpertext]:not([helpertext='']), [errortext]:not([errortext='']))),
-      &:has(ion-input .input-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))),
-      &:has(ion-textarea .textarea-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))) {
-        --inner-border-width: 0;
-        --inner-padding-bottom: 4px;
-      }
-      ion-select .select-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
-      ion-input .input-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
-      ion-textarea .textarea-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))) {
-        display: none;
-      }
-
       &:has(> ion-label:not([slot])):has(> ion-note:not([slot])) {
         &::part(container) {
           flex-direction: column;


### PR DESCRIPTION
## Summary

- extract support-text handling from the inset-only layout mixin
- apply it to every ion-item inside themed iOS lists
- extend the optional MD list stylesheet to non-inset lists while preserving inset-only layout rules
- preserve the existing radio-group support-text inset

This lets input, textarea, and select helper/error areas render correctly in both inset and non-inset lists, including items under reorder, accordion, and radio groups.

## Verification

- npm run build
- Prettier check for the changed SCSS files
- git diff --check
- inspected generated iOS and MD CSS selectors for the non-inset list scope