### PR TITLE
fix: apply inset styles to all list groups

### DIFF
--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -16,6 +16,11 @@ ion-list.list-inset.ios:not(.ios26-disabled) {
     display: block;
   }
 
+  ion-radio-group > .radio-group-top {
+    padding-inline-start: calc(var(--ion-safe-area-left, 0) + 20px);
+    padding-inline-end: calc(var(--ion-safe-area-right, 0) + 20px);
+  }
+
   :is(#{structured-list.$groups}):not(:is(#{structured-list.$groups}) :is(#{structured-list.$groups})) {
     ion-item {
       // To draw lines inside

--- a/src/styles/components/ion-list.scss
+++ b/src/styles/components/ion-list.scss
@@ -16,9 +16,7 @@ ion-list.list-inset.ios:not(.ios26-disabled) {
     display: block;
   }
 
-  $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group;
-
-  :is(#{$groups}):not(:is(#{$groups}) :is(#{$groups})) {
+  :is(#{structured-list.$groups}):not(:is(#{structured-list.$groups}) :is(#{structured-list.$groups})) {
     ion-item {
       // To draw lines inside
       --inner-padding-end: 0;

--- a/src/styles/md-ion-list-inset.scss
+++ b/src/styles/md-ion-list-inset.scss
@@ -5,7 +5,7 @@ ion-list.md {
 
   &.list-inset {
     @include structured-list.layout(8px, 16px);
-    ion-item-group > ion-item {
+    :is(#{structured-list.$groups}) ion-item {
       & > ion-input[labelplacement='floating'] {
         transition: transform 200ms ease;
 

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -77,6 +77,7 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
   }
 
   :is(#{$groups}):not(:is(#{$groups}) :is(#{$groups})) {
+    display: block;
     border-radius: $group-border-radius;
     overflow: hidden;
 

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -4,6 +4,7 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
   ion-item {
     &:has(ion-input.input-fill-outline),
     &:has(ion-textarea.textarea-fill-outline),
+    &:has(ion-select:is([helpertext]:not([helpertext='']), [errortext]:not([errortext='']))),
     &:has(ion-input .input-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))),
     &:has(ion-textarea .textarea-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))) {
       --inner-border-width: 0;

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -4,14 +4,12 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
   ion-item {
     &:has(ion-input.input-fill-outline),
     &:has(ion-textarea.textarea-fill-outline),
-    &:has(ion-select:is([helpertext]:not([helpertext='']), [errortext]:not([errortext='']))),
     &:has(ion-input .input-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))),
     &:has(ion-textarea .textarea-bottom > :is(.helper-text:not(:empty), .error-text:not(:empty))) {
       --inner-border-width: 0;
       --inner-padding-bottom: 4px;
     }
 
-    ion-select .select-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
     ion-input .input-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))),
     ion-textarea .textarea-bottom:not(:has(> :is(.helper-text:not(:empty), .error-text:not(:empty)))) {
       display: none;

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -89,8 +89,6 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
         order: 1;
         font-size: 0.9rem;
         padding-block-start: 8px;
-        padding-inline-start: calc(var(--ion-safe-area-left, 0) + #{$outer-note-inset});
-        padding-inline-end: calc(var(--ion-safe-area-right, 0) + #{$outer-note-inset});
       }
 
       > ion-item:first-of-type {

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -1,3 +1,5 @@
+$groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group;
+
 @mixin support-text() {
   ion-item {
     &:has(ion-input.input-fill-outline),
@@ -74,8 +76,6 @@
     }
   }
 
-  $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group;
-
   :is(#{$groups}):not(:is(#{$groups}) :is(#{$groups})) {
     border-radius: $group-border-radius;
     overflow: hidden;
@@ -90,8 +90,8 @@
         order: 1;
         font-size: 0.9rem;
         padding-block-start: 8px;
-        padding-inline-start: calc(var(--ion-safe-area-left, 0) + 20px);
-        padding-inline-end: calc(var(--ion-safe-area-right, 0) + 20px);
+        padding-inline-start: calc(var(--ion-safe-area-left, 0) + #{$outer-note-inset});
+        padding-inline-end: calc(var(--ion-safe-area-right, 0) + #{$outer-note-inset});
       }
 
       > ion-item:first-of-type {


### PR DESCRIPTION
## Summary

- share the supported structured-list group selector list between the iOS and MD inset styles
- apply MD fallback inset input styles to item, reorder, accordion, and radio groups
- use descendant selectors so wrapped ion-item components remain supported
- derive radio helper/error text padding from the layout's outer inset

The generated padding remains 20px for iOS and resolves to 8px for the MD fallback.

## Verification

- npm run build
- Prettier check for the changed SCSS files
- git diff --check
- inspected generated iOS and MD CSS for all four group selectors and their respective 20px/8px insets
- confirmed structured-list.scss is byte-identical with ionic-theme-md3