### PR TITLE
refactor: prefer CSS custom properties over Shadow Parts

### DIFF
--- a/src/styles/components/ion-button.scss
+++ b/src/styles/components/ion-button.scss
@@ -23,7 +23,7 @@ $scaleup-large-icon-only: 1.22;
   /**
    * compare .header-collapse-main ion-toolbar.in-toolbar ion-title, .header-collapse-main ion-toolbar.in-toolbar ion-buttons
    */
-  transition: transform var(--ios26-activated-transition-duration) ease-out !important;
+  transition: transform var(--ios26-activated-transition-duration) ease-out;
 
   z-index: 0;
 
@@ -117,7 +117,7 @@ $scaleup-large-icon-only: 1.22;
     }
 
     &::part(native) {
-      backdrop-filter: none !important;
+      backdrop-filter: none;
     }
   }
 
@@ -396,6 +396,13 @@ $scaleup-large-icon-only: 1.22;
 
 ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button:not(.button-clear), ion-menu-button.menu-button-hidden)) {
   @include theme-buttons;
+}
+
+// Ionic's collapsing-header transition has a more specific contextual selector.
+.header-collapse-main
+  :where(ion-toolbar.in-toolbar)
+  ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button:not(.button-clear), ion-menu-button.menu-button-hidden)) {
+  transition: transform var(--ios26-activated-transition-duration) ease-out;
 }
 
 ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button.button-clear)) {

--- a/src/styles/components/ion-button.scss
+++ b/src/styles/components/ion-button.scss
@@ -64,6 +64,10 @@ $scaleup-large-icon-only: 1.22;
   }
 
   ion-button:not(.ios26-disabled).button-clear {
+    --background: transparent;
+    --border-style: none;
+    --border-width: 0;
+    --box-shadow: none;
     transform: none;
 
     font-weight: 500;
@@ -75,13 +79,13 @@ $scaleup-large-icon-only: 1.22;
       --padding-end: 0.5em;
     }
     &.button-default {
+      --padding-bottom: 0;
+      --padding-end: 12px;
+      --padding-start: 12px;
+      --padding-top: 0;
       &::part(native) {
         min-height: calc(44px - 2px); // reduce for border 2px;
       }
-      --padding-top: 16px;
-      --padding-bottom: 16px;
-      --padding-start: 1em;
-      --padding-end: 1em;
     }
     &.button-large {
       min-height: calc(62px - 2px);
@@ -113,13 +117,6 @@ $scaleup-large-icon-only: 1.22;
     }
 
     &::part(native) {
-      /**
-       * overwrite theme-button mixin.
-       * ex) ion-button.ios:not(.ios26-disabled):not(.button-solid):not(.ios26-button-solid):not(.button-outline):not(.ios26-button-outline):not(.button-clear):not(.ios26-button-clear)::part(native)
-       */
-      box-shadow: none !important;
-      border: none !important;
-      background: transparent !important;
       backdrop-filter: none !important;
     }
   }
@@ -135,7 +132,7 @@ $scaleup-large-icon-only: 1.22;
   }
 }
 
-@mixin theme-button() {
+@mixin theme-button($is-back-button: false) {
   max-height: inherit;
   z-index: 0;
   &.ion-activated {
@@ -146,8 +143,13 @@ $scaleup-large-icon-only: 1.22;
     transform var(--ios26-activated-transition-duration) ease-out,
     color 50ms ease;
 
-  &.in-toolbar:not(.ion-color):not(.in-toolbar-color)::part(native) {
-    color: inherit;
+  &.in-toolbar:not(.ion-color):not(.in-toolbar-color) {
+    --ion-toolbar-color: currentColor;
+
+    &.button-solid {
+      --ion-toolbar-color: var(--background);
+      --ion-toolbar-background: currentColor;
+    }
   }
 
   // will-change is optimized to only apply when needed for performance
@@ -165,9 +167,16 @@ $scaleup-large-icon-only: 1.22;
   &:not(.button-small):not(.button-large) {
     font-size: 1.05rem;
     &:not(.button-has-icon-only):not(.back-button-has-icon-only) {
-      &::part(native) {
-        padding: 0 12px;
-        min-height: 44px;
+      --padding-bottom: 0;
+      --padding-end: 12px;
+      --padding-start: 12px;
+      --padding-top: 0;
+      @if $is-back-button {
+        --min-height: 44px;
+      } @else {
+        &::part(native) {
+          min-height: 44px;
+        }
       }
       ion-icon[slot='start'] {
         margin-inline-start: -0.15em;
@@ -223,26 +232,33 @@ $scaleup-large-icon-only: 1.22;
     }
     &::part(native) {
       position: relative;
-      color: var(--color);
       z-index: 0;
+    }
+    &.ion-color::part(native) {
+      color: var(--color);
     }
     &.ion-activated {
       --border-width: 0.78px;
-      &::part(native) {
-        @include api.glass-background-button-activated;
-        color: var(--color-activated);
-        &::before {
-          content: '';
-          z-index: 1;
-          width: 100%;
-          height: 100%;
-          position: absolute;
-          top: 0;
-          left: 0;
-          border-radius: inherit;
-          pointer-events: none;
-          backdrop-filter: brightness(144%);
+      @if $is-back-button {
+        &::part(native) {
+          @include api.glass-background-button-activated;
         }
+      } @else {
+        --box-shadow:
+          inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2),
+          0 0 8px -4px rgba(var(--ios26-glass-box-shadow-color-rgb), 0.92);
+      }
+      &::part(native)::before {
+        content: '';
+        z-index: 1;
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        backdrop-filter: brightness(144%);
       }
       &.ion-activated.button-has-icon-only,
       &.ion-activated.back-button-has-icon-only {
@@ -266,19 +282,34 @@ $scaleup-large-icon-only: 1.22;
       }
     }
     &.button-disabled {
+      --background: var(--ion-background-color-step-200, #cccccc);
       opacity: 1;
       &::part(native) {
-        background: var(--ion-background-color-step-200, #cccccc);
         color: #fff;
-        border: none;
+      }
+      &.ion-color::part(native) {
+        background: var(--background);
+      }
+      @if $is-back-button {
+        &::part(native) {
+          border: none;
+        }
+      } @else {
+        --border-style: none;
+        --border-width: 0;
       }
     }
   }
 
   // fill:default only
   &:not(.button-solid):not(.button-outline):not(.button-clear) {
+    --background: rgba(var(--ios26-glass-background-rgb), 0.72);
     --background-hover: transparent;
     --background-activated: transparent;
+    @if not $is-back-button {
+      --box-shadow:
+        inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2), 0 0 10px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.82);
+    }
 
     &:not(.button-has-icon-only):not(.back-button-has-icon-only) {
       &:not(.button-small):not(.button-large) {
@@ -287,8 +318,7 @@ $scaleup-large-icon-only: 1.22;
     }
 
     &::part(native) {
-      @include api.glass-background;
-      color: var(--color);
+      @include api.glass-background($include-background: false, $include-box-shadow: $is-back-button);
     }
 
     &:not(.button-disabled) {
@@ -302,6 +332,7 @@ $scaleup-large-icon-only: 1.22;
       --color: rgba(var(--ion-color-base-rgb, var(--ion-text-color-rgb, 0, 0, 0)), 1);
     }
     &.ion-activated {
+      --opacity: 1; // for ion-back-button
       --color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.1);
       &.ion-color {
         --color: rgba(var(--ion-color-base-rgb, var(--ion-text-color-rgb, 0, 0, 0)), 0.1);
@@ -326,9 +357,6 @@ $scaleup-large-icon-only: 1.22;
           transform: scale($scaleup-large);
         }
       }
-      &::part(native) {
-        opacity: 1; // for ion-back-button
-      }
     }
     &.button-disabled {
       opacity: 1;
@@ -341,10 +369,20 @@ $scaleup-large-icon-only: 1.22;
 
   &.button-has-icon-only,
   &.back-button-has-icon-only {
-    &:not(.button-small):not(.button-large)::part(native) {
-      width: 44px;
-      height: 44px;
-      padding: 2px;
+    &:not(.button-small):not(.button-large) {
+      --padding-bottom: 2px;
+      --padding-end: 2px;
+      --padding-start: 2px;
+      --padding-top: 2px;
+      @if $is-back-button {
+        --min-height: 44px;
+        --min-width: 44px;
+      } @else {
+        &::part(native) {
+          width: 44px;
+          height: 44px;
+        }
+      }
     }
 
     ion-icon {
@@ -379,5 +417,5 @@ ion-button.ios:not(.ios26-disabled) {
   @include theme-button;
 }
 ion-back-button.ios:not(.ios26-disabled) {
-  @include theme-button;
+  @include theme-button($is-back-button: true);
 }

--- a/src/styles/components/ion-fab.scss
+++ b/src/styles/components/ion-fab.scss
@@ -11,6 +11,9 @@ ion-fab.ios:not(.ios26-disabled) {
   }
 
   ion-fab-button {
+    --background: rgba(var(--ios26-glass-background-rgb), 0.72);
+    --box-shadow:
+      inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2), 0 0 10px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.82);
     --transition:
       var(--ios26-activated-transition-duration) transform cubic-bezier(0.25, 1.11, 0.78, 1.59),
       var(--ios26-activated-transition-duration) color ease;
@@ -56,7 +59,10 @@ ion-fab.ios:not(.ios26-disabled) {
     }
 
     &::part(native) {
-      @include api.glass-background;
+      @include api.glass-background($include-background: false, $include-box-shadow: false);
+      // The previous background shorthand reset Ionic's padding-box default.
+      // There is no CSS custom property for background-clip, so preserve it via the Part.
+      background-clip: border-box;
     }
   }
 

--- a/src/styles/components/ion-modal.scss
+++ b/src/styles/components/ion-modal.scss
@@ -34,8 +34,9 @@ ion-modal.ios:not(.ios26-disabled) {
 
   &.modal-sheet {
     --border-radius: 30px;
+    --background: rgba(var(--ios26-glass-background-rgb), 1);
     &::part(content) {
-      @include api.glass-background($opacity: 1);
+      @include api.glass-background($opacity: 1, $include-background: false);
     }
   }
 }

--- a/src/styles/components/ion-popover.scss
+++ b/src/styles/components/ion-popover.scss
@@ -2,6 +2,9 @@
 
 ion-popover.ios:not(.ios26-disabled) {
   --backdrop-opacity: 0.2;
+  --background: rgba(var(--ios26-glass-background-rgb), 0.72);
+  --box-shadow:
+    inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2), 0 0 10px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.82);
   &::part(arrow) {
     display: none;
     ::after {
@@ -9,7 +12,7 @@ ion-popover.ios:not(.ios26-disabled) {
     }
   }
   &::part(content) {
-    @include api.glass-background;
+    @include api.glass-background($include-background: false, $include-box-shadow: false);
     border-radius: 24px;
     padding: 0;
   }

--- a/src/styles/components/ion-range.scss
+++ b/src/styles/components/ion-range.scss
@@ -36,28 +36,28 @@ ion-range.ios:not(.ios26-disabled) {
   }
 
   &:not(.range-dual-knobs).range-pressed {
+    --knob-background: rgba(var(--ios26-glass-background-rgb), 0.1);
+    --knob-box-shadow: 0 0.5px 4px rgba(0, 0, 0, 0.12), 0 6px 4px rgba(0, 0, 0, 0.05), inset 0.4px 0.4px 1px 0 var(--bar-background-active);
+
     &::part(knob) {
       @include scaled-transform(0px);
-      @include api.glass-background(0.1, 0, 120%);
-      border: none;
-      box-shadow:
-        0 0.5px 4px rgba(0, 0, 0, 0.12),
-        0 6px 4px rgba(0, 0, 0, 0.05),
-        inset 0.4px 0.4px 1px 0 var(--bar-background-active);
+      @include api.glass-background(0.1, 0, 120%, $include-background: false, $include-box-shadow: false, $include-border: false);
     }
 
-    &.range-value-min::part(knob) {
-      @include scaled-transform(calc(var(--knob-width) * -2));
-      box-shadow:
-        0 0.5px 4px rgba(0, 0, 0, 0.12),
-        0 6px 4px rgba(0, 0, 0, 0.05);
+    &.range-value-min {
+      --knob-box-shadow: 0 0.5px 4px rgba(0, 0, 0, 0.12), 0 6px 4px rgba(0, 0, 0, 0.05);
+
+      &::part(knob) {
+        @include scaled-transform(calc(var(--knob-width) * -2));
+      }
     }
-    &.range-value-max::part(knob) {
-      @include scaled-transform(calc(var(--knob-width) * 2));
-      box-shadow:
-        0 0.5px 4px rgba(0, 0, 0, 0.12),
-        0 6px 4px rgba(0, 0, 0, 0.05),
-        inset 0.4px 0.4px 1px 0.2px var(--bar-background-active);
+    &.range-value-max {
+      --knob-box-shadow:
+        0 0.5px 4px rgba(0, 0, 0, 0.12), 0 6px 4px rgba(0, 0, 0, 0.05), inset 0.4px 0.4px 1px 0.2px var(--bar-background-active);
+
+      &::part(knob) {
+        @include scaled-transform(calc(var(--knob-width) * 2));
+      }
     }
   }
 
@@ -65,8 +65,7 @@ ion-range.ios:not(.ios26-disabled) {
     &.range-pressed-a::part(knob-a),
     &.range-pressed-b::part(knob-b) {
       @include scaled-transform(0px);
-      @include api.glass-background(0.1, 0, 120%);
-      border: none;
+      @include api.glass-background(0.1, 0, 120%, $include-border: false);
       box-shadow:
         0 0.5px 4px rgba(0, 0, 0, 0.12),
         0 6px 4px rgba(0, 0, 0, 0.05),

--- a/src/styles/components/ion-range.scss
+++ b/src/styles/components/ion-range.scss
@@ -1,8 +1,8 @@
 @use '../utils/api';
 
 @mixin scaled-transform($translate-x) {
-  transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0) !important;
-  -webkit-transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0) !important;
+  transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0);
+  -webkit-transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0);
 }
 
 ion-range.ios:not(.ios26-disabled) {
@@ -40,8 +40,8 @@ ion-range.ios:not(.ios26-disabled) {
     --knob-box-shadow: 0 0.5px 4px rgba(0, 0, 0, 0.12), 0 6px 4px rgba(0, 0, 0, 0.05), inset 0.4px 0.4px 1px 0 var(--bar-background-active);
 
     &::part(knob) {
-      @include scaled-transform(0px);
       @include api.glass-background(0.1, 0, 120%, $include-background: false, $include-box-shadow: false, $include-border: false);
+      @include scaled-transform(0px);
     }
 
     &.range-value-min {
@@ -64,8 +64,8 @@ ion-range.ios:not(.ios26-disabled) {
   &.range-dual-knobs.range-pressed {
     &.range-pressed-a::part(knob-a),
     &.range-pressed-b::part(knob-b) {
-      @include scaled-transform(0px);
       @include api.glass-background(0.1, 0, 120%, $include-border: false);
+      @include scaled-transform(0px);
       box-shadow:
         0 0.5px 4px rgba(0, 0, 0, 0.12),
         0 6px 4px rgba(0, 0, 0, 0.05),

--- a/src/styles/components/ion-searchbar.scss
+++ b/src/styles/components/ion-searchbar.scss
@@ -27,11 +27,17 @@ ion-searchbar.ios:not(.ios26-disabled):not(.searchbar-classic) {
       min-height: 44px;
       @include api.glass-background;
       border-radius: 20px;
-      padding-inline-start: 2.4rem !important;
+      padding-inline-start: 2.4rem;
     }
     .searchbar-clear-button {
       padding-inline-end: 2rem;
     }
+  }
+
+  // Ionic writes a physical inline padding while the placeholder is centered.
+  // Match before hydration as well, so Ionic's `transition: all` cannot animate through the inline value.
+  &:not(.searchbar-left-aligned) .searchbar-input-container input.searchbar-input {
+    padding-inline-start: 2.4rem !important;
   }
 }
 
@@ -39,16 +45,16 @@ ion-searchbar.ios:not(.ios26-disabled):not(.searchbar-classic) {
  * add searchbar-classic
  */
 ion-toolbar.ios:not(.ios26-disabled):has(ion-searchbar.searchbar-classic.ios:not(.ios26-disabled)) {
-  --min-height: auto !important;
+  --min-height: auto;
 }
 ion-searchbar.ios:not(.ios26-disabled).searchbar-classic {
   padding-bottom: 12px;
   min-height: auto;
-  input.searchbar-input {
+  .searchbar-input-container input.searchbar-input {
     border-radius: 999px;
     height: 44px;
     font-size: 0.98rem;
-    padding-inline-start: 38px !important;
+    padding-inline-start: 38px;
     background: rgba(var(--ion-color-contrast-rgb), 0.078);
   }
   ion-icon.searchbar-search-icon {

--- a/src/styles/components/ion-segment.scss
+++ b/src/styles/components/ion-segment.scss
@@ -17,6 +17,11 @@ ion-segment.ios:not(.ios26-disabled) {
     will-change: auto;
   }
 
+  ion-segment-button:is(.in-toolbar-color, .in-segment-color)::part(indicator-background) {
+    // Ionic sets a direct background for color contexts, bypassing --indicator-color.
+    background: var(--indicator-color);
+  }
+
   &.in-toolbar-color:not(.in-segment-color) {
     ion-segment-button:not(.segment-button-checked)::part(native) {
       color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 1) !important;
@@ -27,6 +32,8 @@ ion-segment.ios:not(.ios26-disabled) {
     transform: scale(1.1) translateZ(0);
     -webkit-transform: scale(1.1) translateZ(0);
     ion-segment-button {
+      --indicator-color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0);
+      --indicator-transform: scale(1.1) translateZ(0);
       transition: transform 100ms ease-out;
       &.segment-button-checked::part(native) {
         transform: scale(1.08) translateZ(0);
@@ -35,9 +42,6 @@ ion-segment.ios:not(.ios26-disabled) {
       &::part(indicator-background) {
         position: relative;
         z-index: 1;
-        background: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0);
-        transform: scale(1.1) translateZ(0);
-        -webkit-transform: scale(1.1) translateZ(0);
         transform-origin: center center;
       }
     }
@@ -48,6 +52,7 @@ ion-segment.ios:not(.ios26-disabled) {
       transform: scale(1.1) translateZ(0);
       -webkit-transform: scale(1.1) translateZ(0);
       ion-segment-button {
+        --indicator-transform: scale(1.1) translateZ(0);
         transition: transform 100ms ease-out;
         &.segment-button-checked::part(native) {
           transform: scale(1.08) translateZ(0);
@@ -56,17 +61,13 @@ ion-segment.ios:not(.ios26-disabled) {
         &::part(indicator-background) {
           position: relative;
           z-index: 1;
-          transform: scale(1.1) translateZ(0);
-          -webkit-transform: scale(1.1) translateZ(0);
           transform-origin: center center;
         }
       }
     }
     &.ios26-animated {
       ion-segment-button {
-        &::part(indicator-background) {
-          background: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0);
-        }
+        --indicator-color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0);
       }
     }
   }
@@ -91,6 +92,7 @@ ion-segment.ios:not(.ios26-disabled) {
         transform: scale(1) translateZ(0);
         -webkit-transform: scale(1) translateZ(0);
         ion-segment-button {
+          --indicator-transform: scale(1) translateZ(0);
           transition: none;
           &.segment-button-checked::part(native) {
             transform: scale(1) translateZ(0);
@@ -99,17 +101,13 @@ ion-segment.ios:not(.ios26-disabled) {
           &::part(indicator-background) {
             position: relative;
             z-index: 1;
-            transform: scale(1) translateZ(0);
-            -webkit-transform: scale(1) translateZ(0);
             transform-origin: center center;
           }
         }
       }
       &.ios26-animated {
         ion-segment-button {
-          &::part(indicator-background) {
-            background: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0);
-          }
+          --indicator-color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0);
         }
       }
     }
@@ -118,6 +116,8 @@ ion-segment.ios:not(.ios26-disabled) {
 
 ion-segment-button.ios:not(.ios26-disabled) {
   --border-width: 0;
+  --indicator-box-shadow: none;
+  --indicator-color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.06);
   --ion-color-base: var(--ion-text-color, #000);
   --padding-start: 8px;
   --padding-end: 8px;
@@ -127,9 +127,7 @@ ion-segment-button.ios:not(.ios26-disabled) {
 
   &::part(indicator-background) {
     border-radius: 25px;
-    box-shadow: none;
     transition: background 0.2s ease;
-    background: rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.06);
   }
 
   &.ion-cloned-element {

--- a/src/styles/components/ion-segment.scss
+++ b/src/styles/components/ion-segment.scss
@@ -24,7 +24,7 @@ ion-segment.ios:not(.ios26-disabled) {
 
   &.in-toolbar-color:not(.in-segment-color) {
     ion-segment-button:not(.segment-button-checked)::part(native) {
-      color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 1) !important;
+      color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 1);
     }
   }
 

--- a/src/styles/components/ion-toast.scss
+++ b/src/styles/components/ion-toast.scss
@@ -1,17 +1,35 @@
 @use '../utils/api';
 
 ion-toast.ios:not(.ios26-disabled) {
-  --background: transparent;
+  --background: rgba(var(--ios26-glass-background-rgb), 0.72);
+  --border-radius: 24px;
+  --border-style: solid;
+  --border-width: 0.5px;
+  --box-shadow:
+    inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2), 0 0 10px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.82);
   --start: 16px;
   --end: 16px;
 
   &::part(wrapper) {
-    @include api.glass-background;
-    border-radius: 24px;
+    @include api.glass-background($include-background: false, $include-box-shadow: false, $include-border: false);
+    border-top-color: rgba(var(--ios26-glass-border-color-rgb), 1);
+    border-right-color: rgba(var(--ios26-glass-border-color-rgb), 0.8);
+    border-bottom-color: rgba(var(--ios26-glass-border-color-rgb), 1);
+    border-left-color: rgba(var(--ios26-glass-border-color-rgb), 0.6);
   }
 
-  &.ion-color::part(wrapper) {
-    @include api.glass-background($background-rgb: var(--ion-color-base-rgb), $border-color-rgb: var(--ion-color-base-rgb));
-    border-radius: 24px;
+  &.ion-color {
+    &::part(wrapper) {
+      @include api.glass-background(
+        $background-rgb: var(--ion-color-base-rgb),
+        $border-color-rgb: var(--ion-color-base-rgb),
+        $include-box-shadow: false,
+        $include-border: false
+      );
+      border-top-color: rgba(var(--ion-color-base-rgb), 1);
+      border-right-color: rgba(var(--ion-color-base-rgb), 0.8);
+      border-bottom-color: rgba(var(--ion-color-base-rgb), 1);
+      border-left-color: rgba(var(--ion-color-base-rgb), 0.6);
+    }
   }
 }

--- a/src/styles/components/ion-toggle.scss
+++ b/src/styles/components/ion-toggle.scss
@@ -43,26 +43,22 @@ ion-toggle.ios:not(.ios26-disabled) {
   &.toggle-activated::part(handle) {
     transform: scale(1.4, 1.6) translateZ(0);
     -webkit-transform: scale(1.4, 1.6) translateZ(0);
-    @include api.glass-background($opacity: 0.1, $blur: 0.5px, $saturate: 120%);
-    transition:
-      transform 280ms,
-      width 120ms ease-in-out 80ms,
-      left 110ms ease-in-out 80ms,
-      right 110ms ease-in-out 80ms;
-    box-shadow: inset 0 0 8px 0 var(--track-background);
+    --handle-transition: transform 280ms, width 120ms ease-in-out 80ms, left 110ms ease-in-out 80ms, right 110ms ease-in-out 80ms;
+    @include api.glass-background($opacity: 0.1, $blur: 0.5px, $saturate: 120%, $include-background: false, $include-box-shadow: false);
   }
-  &.ion-color.toggle-checked.toggle-activated::part(handle) {
-    box-shadow:
-      inset 0 8px 8px -8px var(--ion-color-base),
-      inset 8px 0 8px -8px var(--track-background),
-      inset 8px 0 8px -8px var(--track-background),
-      inset -8px 0 8px -8px var(--ion-color-base);
+  &.toggle-activated {
+    --handle-background: rgba(var(--ios26-glass-background-rgb), 0.1);
+    --handle-background-checked: rgba(var(--ios26-glass-background-rgb), 0.1);
+    --handle-box-shadow: inset 0 0 8px 0 var(--track-background);
   }
-  &.toggle-checked.toggle-activated::part(handle) {
-    box-shadow:
-      inset 0 8px 8px -8px var(--track-background-checked),
-      inset 8px 0 8px -8px var(--track-background),
-      inset 8px 0 8px -8px var(--track-background),
-      inset -8px 0 8px -8px var(--track-background-checked);
+  &.ion-color.toggle-checked.toggle-activated {
+    --handle-box-shadow:
+      inset 0 8px 8px -8px var(--ion-color-base), inset 8px 0 8px -8px var(--track-background),
+      inset 8px 0 8px -8px var(--track-background), inset -8px 0 8px -8px var(--ion-color-base);
+  }
+  &.toggle-checked.toggle-activated {
+    --handle-box-shadow:
+      inset 0 8px 8px -8px var(--track-background-checked), inset 8px 0 8px -8px var(--track-background),
+      inset 8px 0 8px -8px var(--track-background), inset -8px 0 8px -8px var(--track-background-checked);
   }
 }

--- a/src/styles/utils/api.scss
+++ b/src/styles/utils/api.scss
@@ -3,17 +3,26 @@
   $blur: 2px,
   $saturate: 360%,
   $background-rgb: var(--ios26-glass-background-rgb),
-  $border-color-rgb: var(--ios26-glass-border-color-rgb)
+  $border-color-rgb: var(--ios26-glass-border-color-rgb),
+  $include-background: true,
+  $include-box-shadow: true,
+  $include-border: true
 ) {
-  background: rgba($background-rgb, $opacity);
+  @if $include-background {
+    background: rgba($background-rgb, $opacity);
+  }
   backdrop-filter: blur($blur) saturate($saturate);
-  box-shadow:
-    inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2),
-    0 0 10px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.82);
-  border-top: 0.5px solid rgba($border-color-rgb, 1);
-  border-right: 0.5px solid rgba($border-color-rgb, 0.8);
-  border-bottom: 0.5px solid rgba($border-color-rgb, 1);
-  border-left: 0.5px solid rgba($border-color-rgb, 0.6);
+  @if $include-box-shadow {
+    box-shadow:
+      inset 0 0 8px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.2),
+      0 0 10px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.82);
+  }
+  @if $include-border {
+    border-top: 0.5px solid rgba($border-color-rgb, 1);
+    border-right: 0.5px solid rgba($border-color-rgb, 0.8);
+    border-bottom: 0.5px solid rgba($border-color-rgb, 1);
+    border-left: 0.5px solid rgba($border-color-rgb, 0.6);
+  }
 
   // Hardware acceleration optimization for glass effects
   transform: translateZ(0);
@@ -28,10 +37,20 @@
     0 0 8px -4px rgba(var(--ios26-glass-box-shadow-color-rgb), 0.92);
 }
 
-@mixin glass-background-button-activated-dark($opacity: 0.56, $blur: 7px, $saturate: 180%) {
-  background: rgba(var(--ios26-button-color-selected-rgb), $opacity);
+@mixin glass-background-button-activated-dark(
+  $opacity: 0.56,
+  $blur: 7px,
+  $saturate: 180%,
+  $include-background: true,
+  $include-box-shadow: true
+) {
+  @if $include-background {
+    background: rgba(var(--ios26-button-color-selected-rgb), $opacity);
+  }
   backdrop-filter: blur($blur) saturate($saturate);
-  box-shadow: inset 0 0 16px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.55);
+  @if $include-box-shadow {
+    box-shadow: inset 0 0 16px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.55);
+  }
   border-top: 0.8px solid rgba(var(--ios26-button-color-selected-rgb), 0.8);
   border-right: 0.8px solid rgba(var(--ios26-button-color-selected-rgb), 0.4);
   border-bottom: 0.8px solid rgba(var(--ios26-button-color-selected-rgb), 0.8);

--- a/src/styles/utils/dark/ion-button.scss
+++ b/src/styles/utils/dark/ion-button.scss
@@ -26,14 +26,18 @@
   }
 }
 
-@mixin theme-dark-button {
+@mixin theme-dark-button($is-back-button: false) {
   &.ion-activated:not(.button-solid):not(.button-outline):not(.button-clear) {
+    --background: rgba(var(--ios26-button-color-selected-rgb), 0.56);
     --color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 1);
+    @if not $is-back-button {
+      --box-shadow: inset 0 0 16px 0 rgba(var(--ios26-glass-box-shadow-color-rgb), 0.55);
+    }
     &.ion-color {
       --color: rgba(var(--ion-color-base-rgb, var(--ion-text-color-rgb, 0, 0, 0)), 1);
     }
     &::part(native) {
-      @include api.glass-background-button-activated-dark;
+      @include api.glass-background-button-activated-dark($include-background: false, $include-box-shadow: $is-back-button);
     }
     ion-icon {
       color: rgb(255, 255, 255) !important;
@@ -45,8 +49,10 @@
   ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button:not(.button-clear))) {
     @include theme-dark-buttons;
   }
-  ion-button:not(.ios26-disabled),
-  ion-back-button:not(.ios26-disabled) {
+  ion-button:not(.ios26-disabled) {
     @include theme-dark-button;
+  }
+  ion-back-button:not(.ios26-disabled) {
+    @include theme-dark-button($is-back-button: true);
   }
 }

--- a/src/styles/utils/dark/ion-button.scss
+++ b/src/styles/utils/dark/ion-button.scss
@@ -40,7 +40,7 @@
       @include api.glass-background-button-activated-dark($include-background: false, $include-box-shadow: $is-back-button);
     }
     ion-icon {
-      color: rgb(255, 255, 255) !important;
+      color: rgb(255, 255, 255);
     }
   }
 }

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -148,7 +148,7 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
           transform: translateY(-7px);
         }
         ion-icon[slot='icon-only'] {
-          font-size: 1.2rem !important;
+          font-size: 1.2rem;
           transform: translateY(4px);
         }
       }

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -135,14 +135,11 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
       }
 
       &.item-disabled {
+        --detail-icon-opacity: 0.1;
         opacity: 1;
 
         & > * {
           opacity: 0.4;
-        }
-
-        &::part(detail-icon) {
-          opacity: 0.1;
         }
       }
 


### PR DESCRIPTION
## Summary
- move eligible component styling from Shadow Parts to documented Ionic CSS custom properties
- keep Shadow Parts only where public variables are unavailable or would affect a different internal element
- preserve existing glass appearance, interaction states, RTL behavior, and user override paths

## Compatibility review
- no demo-specific IDs, routes, fixtures, or DOM ordering assumptions
- selectors use Ionic components and standard runtime state classes
- user overrides remain possible through ordinary later CSS custom-property declarations
- manager review and independent acceptance review completed with no blocking findings

## Validation
- npm run build
- Prettier check for src
- git diff --check
- 87 Mac Chrome light/dark screenshots matched the before-change baseline; the excluded dark sheet case is an unchanged baseline flake
- verified pressed single/dual range transforms and collapsing-header button behavior

Linux Playwright snapshots were not modified.

Important-declaration cleanup is intentionally split into a separate stacked PR.