### PR TITLE
refactor: remove unnecessary important declarations

### DIFF
--- a/src/styles/components/ion-button.scss
+++ b/src/styles/components/ion-button.scss
@@ -23,7 +23,7 @@ $scaleup-large-icon-only: 1.22;
   /**
    * compare .header-collapse-main ion-toolbar.in-toolbar ion-title, .header-collapse-main ion-toolbar.in-toolbar ion-buttons
    */
-  transition: transform var(--ios26-activated-transition-duration) ease-out !important;
+  transition: transform var(--ios26-activated-transition-duration) ease-out;
 
   z-index: 0;
 
@@ -117,7 +117,7 @@ $scaleup-large-icon-only: 1.22;
     }
 
     &::part(native) {
-      backdrop-filter: none !important;
+      backdrop-filter: none;
     }
   }
 
@@ -396,6 +396,13 @@ $scaleup-large-icon-only: 1.22;
 
 ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button:not(.button-clear), ion-menu-button.menu-button-hidden)) {
   @include theme-buttons;
+}
+
+// Ionic's collapsing-header transition has a more specific contextual selector.
+.header-collapse-main
+  :where(ion-toolbar.in-toolbar)
+  ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button:not(.button-clear), ion-menu-button.menu-button-hidden)) {
+  transition: transform var(--ios26-activated-transition-duration) ease-out;
 }
 
 ion-buttons.ios:not(.ios26-disabled):not(:has(ion-back-button, ion-button.button-clear)) {

--- a/src/styles/components/ion-range.scss
+++ b/src/styles/components/ion-range.scss
@@ -1,8 +1,8 @@
 @use '../utils/api';
 
 @mixin scaled-transform($translate-x) {
-  transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0) !important;
-  -webkit-transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0) !important;
+  transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0);
+  -webkit-transform: scale(1.56, 1.47) translateX(calc(#{$translate-x} * -0.1)) translateZ(0);
 }
 
 ion-range.ios:not(.ios26-disabled) {
@@ -40,8 +40,8 @@ ion-range.ios:not(.ios26-disabled) {
     --knob-box-shadow: 0 0.5px 4px rgba(0, 0, 0, 0.12), 0 6px 4px rgba(0, 0, 0, 0.05), inset 0.4px 0.4px 1px 0 var(--bar-background-active);
 
     &::part(knob) {
-      @include scaled-transform(0px);
       @include api.glass-background(0.1, 0, 120%, $include-background: false, $include-box-shadow: false, $include-border: false);
+      @include scaled-transform(0px);
     }
 
     &.range-value-min {
@@ -64,8 +64,8 @@ ion-range.ios:not(.ios26-disabled) {
   &.range-dual-knobs.range-pressed {
     &.range-pressed-a::part(knob-a),
     &.range-pressed-b::part(knob-b) {
-      @include scaled-transform(0px);
       @include api.glass-background(0.1, 0, 120%, $include-border: false);
+      @include scaled-transform(0px);
       box-shadow:
         0 0.5px 4px rgba(0, 0, 0, 0.12),
         0 6px 4px rgba(0, 0, 0, 0.05),

--- a/src/styles/components/ion-searchbar.scss
+++ b/src/styles/components/ion-searchbar.scss
@@ -27,11 +27,17 @@ ion-searchbar.ios:not(.ios26-disabled):not(.searchbar-classic) {
       min-height: 44px;
       @include api.glass-background;
       border-radius: 20px;
-      padding-inline-start: 2.4rem !important;
+      padding-inline-start: 2.4rem;
     }
     .searchbar-clear-button {
       padding-inline-end: 2rem;
     }
+  }
+
+  // Ionic writes a physical inline padding while the placeholder is centered.
+  // Match before hydration as well, so Ionic's `transition: all` cannot animate through the inline value.
+  &:not(.searchbar-left-aligned) .searchbar-input-container input.searchbar-input {
+    padding-inline-start: 2.4rem !important;
   }
 }
 
@@ -39,16 +45,16 @@ ion-searchbar.ios:not(.ios26-disabled):not(.searchbar-classic) {
  * add searchbar-classic
  */
 ion-toolbar.ios:not(.ios26-disabled):has(ion-searchbar.searchbar-classic.ios:not(.ios26-disabled)) {
-  --min-height: auto !important;
+  --min-height: auto;
 }
 ion-searchbar.ios:not(.ios26-disabled).searchbar-classic {
   padding-bottom: 12px;
   min-height: auto;
-  input.searchbar-input {
+  .searchbar-input-container input.searchbar-input {
     border-radius: 999px;
     height: 44px;
     font-size: 0.98rem;
-    padding-inline-start: 38px !important;
+    padding-inline-start: 38px;
     background: rgba(var(--ion-color-contrast-rgb), 0.078);
   }
   ion-icon.searchbar-search-icon {

--- a/src/styles/components/ion-segment.scss
+++ b/src/styles/components/ion-segment.scss
@@ -24,7 +24,7 @@ ion-segment.ios:not(.ios26-disabled) {
 
   &.in-toolbar-color:not(.in-segment-color) {
     ion-segment-button:not(.segment-button-checked)::part(native) {
-      color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 1) !important;
+      color: rgba(var(--ion-text-color-rgb, 0, 0, 0), 1);
     }
   }
 

--- a/src/styles/utils/dark/ion-button.scss
+++ b/src/styles/utils/dark/ion-button.scss
@@ -40,7 +40,7 @@
       @include api.glass-background-button-activated-dark($include-background: false, $include-box-shadow: $is-back-button);
     }
     ion-icon {
-      color: rgb(255, 255, 255) !important;
+      color: rgb(255, 255, 255);
     }
   }
 }

--- a/src/styles/utils/structured-list.scss
+++ b/src/styles/utils/structured-list.scss
@@ -148,7 +148,7 @@ $groups: ion-item-group, ion-reorder-group, ion-accordion-group, ion-radio-group
           transform: translateY(-7px);
         }
         ion-icon[slot='icon-only'] {
-          font-size: 1.2rem !important;
+          font-size: 1.2rem;
           transform: translateY(4px);
         }
       }


### PR DESCRIPTION
## Summary
- remove normal-cascade important declarations where selector specificity is already sufficient
- use a narrowly scoped collapsing-header selector where additional specificity is required
- reorder range mixins so the intended transform wins without important
- reduce searchbar important usage from three broad declarations to one centered-placeholder state required to override Ionic inline padding

## Compatibility
- this PR is intentionally stacked on #133 so it contains only important cleanup
- the resulting combined source is identical to the previously reviewed and Mac-verified implementation
- no demo-specific selectors or fixture assumptions
- manager and independent acceptance reviews completed with no blocking findings

## Validation
- npm run build
- Prettier check for src
- git diff --check
- affected Mac Chrome light/dark screenshots matched the before-change baseline
- verified collapsing-header transition and pressed single/dual range computed styles

Linux Playwright snapshots were not modified.