### PR TITLE
Fix opaque toolbar background in translucent headers

### DIFF
--- a/src/styles/utils/translucent.scss
+++ b/src/styles/utils/translucent.scss
@@ -32,6 +32,7 @@ ion-header.ios:not(.ios26-disabled).header-translucent:not(.header-collapse-cond
     --border-color: var(--ion-toolbar-border-color, rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.08));
     &::part(background) {
       --opacity: 1;
+      background: transparent;
     }
   }
 }


### PR DESCRIPTION
The last toolbar's background layer is enabled to show the header's bottom border. Ionic's color styling can give that layer an opaque background, obscuring content behind the translucent header while scrolling.

Explicitly make that layer's background transparent so it draws only the border. The header continues to own the translucent tint and blur.

Validation: `npm run build`, Prettier, and `git diff --check` passed. Headless Chrome confirmed the toolbar's computed background changed from opaque `rgb(242, 242, 247)` to transparent on `/main/settings`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rdlabo-dev/ionic-theme-ios26/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->