### PR TITLE
Fix iOS 26 release tag trigger and version extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'ios26-v*'
   issue_comment:
     types: [created]
   workflow_run:
@@ -81,7 +81,7 @@ jobs:
         id: tag_version
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          VERSION=${TAG_NAME#v}
+          VERSION=${TAG_NAME#ios26-v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION from tag: $TAG_NAME"

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ When a pull request is merged into `main` or `ios26`, it is automatically publis
 
 Candidate code is built in a read-only workflow without npm publishing credentials. The privileged release workflow never checks out or executes pull request code; it revalidates the source workflow and package identity, then publishes only the immutable packed artifact with lifecycle scripts disabled. The install-command comment is a separate best-effort notification and cannot invalidate a successful npm publish.
 
-Only `npm run release` can create a release tag. Stable `vX.Y.Z` tags (major, minor, or patch releases) publish to npm `latest`; revision/prerelease tags publish to `next`. Neither `beta` nor `next` publishing changes the npm `latest` dist-tag.
+Only `npm run release` can create a release tag. Stable `ios26-vX.Y.Z` tags (major, minor, or patch releases) publish to npm `latest`; revision/prerelease tags publish to `next`. Neither `beta` nor `next` publishing changes the npm `latest` dist-tag.
 
 <!-- /rdlabo-docs-omit -->
 


### PR DESCRIPTION
The iOS 26 release command creates `ios26-v*` tags via `.npmrc`, but the workflow only accepted `v*`, so `ios26-v9.2.0-0` did not trigger npm publishing.

Match `ios26-v*` and strip that prefix when validating the package version. Update the README tag example. The main branch already correctly uses `ios27-v*` and needs no change.

Validation: confirmed the current branch configuration and verified `ios26-v9.2.0-0` extracts to `9.2.0-0`; diff check passed. No release was published. Existing tags still contain their original workflow; this fix applies to newly created tags containing the change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rdlabo-dev/ionic-theme-ios27/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->