### PR TITLE
Fix iOS 26 npm provenance repository mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/rdlabo-dev/ionic-theme-ios26.git"
+    "url": "git+ssh://git@github.com/rdlabo-dev/ionic-theme-ios27.git"
   },
   "keywords": [
     "ionic",
@@ -44,7 +44,7 @@
   "author": "Masahiko Sakakibara <sakakibara@rdlabo.jp>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rdlabo-dev/ionic-theme-ios26/issues"
+    "url": "https://github.com/rdlabo-dev/ionic-theme-ios27/issues"
   },
   "homepage": "https://docs.rdlabo.dev/projects/ionic-theme-ios26",
   "devDependencies": {


### PR DESCRIPTION
Publishing `@rdlabo/ionic-theme-ios26@9.2.0-1` failed with npm E422 because `repository.url` still pointed to the old GitHub repository name, which did not match the provenance identity.

Update repository and issue URLs to `rdlabo-dev/ionic-theme-ios27`, keeping the npm package name unchanged. Verified the failure in run 34461506143 and checked the metadata diff. A new release containing this fix is needed; rerunning the old tag will retain the mismatched metadata.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rdlabo-dev/ionic-theme-ios27/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->